### PR TITLE
fix: Remove check on keras version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 url = https://energyflow.network
-project_urls = 
+project_urls =
     Source Code = https://github.com/pkomiske/EnergyFlow
     Issues = https://github.com/pkomiske/EnergyFlow/issues
 
@@ -98,12 +98,12 @@ generation =
     python-igraph
 
 examples =
-    tensorflow > 2.0.0
+    tensorflow >= 2.5.0
     scikit-learn
     matplotlib
 
 archs =
-    tensorflow > 2.0.0
+    tensorflow >= 2.5.0
     scikit-learn
 
 tests =
@@ -111,12 +111,12 @@ tests =
     pytest
     python-igraph
     python-igraph == 0.8.3; python_version=='2.7'
-    tensorflow > 2.0.0
+    tensorflow >= 2.5.0
     scikit-learn
 
 all =
     python-igraph
-    tensorflow > 2.0.0
+    tensorflow >= 2.5.0
     scikit-learn
 
 [bdist_wheel]


### PR DESCRIPTION
* Amends https://github.com/thaler-lab/EnergyFlow/commit/d01860f742c4ff4b120c5e338f3a73ae3a264ba7 with respect to Issue https://github.com/thaler-lab/EnergyFlow/issues/29.
* Effectively reverts https://github.com/thaler-lab/EnergyFlow/commit/841710fff5351dee50efaf891a7afe843c738e16 from release [`v0.13.2`](https://github.com/thaler-lab/EnergyFlow/releases/tag/v0.13.2).

## Description

* To support Python `3.7+`, require `tensorflow` `v2.5.0+` in the extras, which will correctly manage compatible versions of keras.

* The check on the version of keras was required to deal with issues between Keras `v2.2.4` and `v2.2.5`. As the minimum required Keras version for `tensorflow` `v2.5.0` is `keras` `v2.5.0.dev` then all Keras versions installed through the EnergyFlow extras will be newer than `v2.2.5` and so the guard check is no longer necessary.

   - c.f. https://github.com/tensorflow/tensorflow/blob/a4dfb8d1a71385bd6d122e4f27f86dcebb96712d/tensorflow/tools/pip_package/setup.py#L107

---

Aside: If the check had needed to stay it is better to not rely on `__version__` as there is no formal requirement that this attribute exist and instead use `importlib.metadata.version` [added in Python 3.8](https://docs.python.org/3.8/library/importlib.metadata.html).

So that would mean swapping

https://github.com/thaler-lab/EnergyFlow/blob/d01860f742c4ff4b120c5e338f3a73ae3a264ba7/energyflow/archs/efn.py#L18

for

```python
try:
    from importlib.metadata import version
    __keras_version__ = version("keras")
except ModuleNotFoundError:
    # importlib.metadata added in Python 3.8
    # c.f. https://docs.python.org/3.8/library/importlib.metadata.html
    from keras import __version__ as __keras_version__
```