### PR TITLE
build: Change dependency name to 'igraph'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ setup_requires=
 [options.extras_require]
 
 generation =
-    python-igraph
+    igraph
 
 examples =
     tensorflow >= 2.5.0
@@ -110,13 +110,12 @@ archs =
 tests =
     pot >= 0.8.0
     pytest
-    python-igraph
-    python-igraph == 0.8.3; python_version=='2.7'
+    igraph
     tensorflow >= 2.5.0
     scikit-learn
 
 all =
-    python-igraph
+    igraph
     tensorflow >= 2.5.0
     scikit-learn
 


### PR DESCRIPTION
Resolves #33 

* From python-igraph's PyPI page (https://pypi.org/project/python-igraph/)

> This package is deprecated; use the igraph package instead. This package
> will be kept in sync with igraph until Sep 1, 2022 and it will not receive
> any updates after Sep 1, 2022.