### PR TITLE
ci: Update CI run triggers

### DIFF
--- a/.github/workflows/test-energyflow.yml
+++ b/.github/workflows/test-energyflow.yml
@@ -3,14 +3,18 @@ name: Tests
 on:
   push:
     branches:
-      - master
+    - master
+  pull_request:
+    branches:
+    - master
+  # Run weekly at 1:23 UTC
+  schedule:
+  - cron: '23 1 * * 0'
+  workflow_dispatch:
 
-env:
-  PYPI: 0
-  PYPITEST: 1
-  TWINE_USERNAME: __token__
-  TWINE_PASSWORD_PYPITEST: ${{ secrets.TWINE_PASSWORD_PYPITEST }}
-  TWINE_PASSWORD_PYPI: ${{ secrets.TWINE_PASSWORD_PYPI }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -18,22 +22,26 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout repository and submodules
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Display Python version
         run: python --version
+
       - name: Install test prerequisites
         run: |
-          pip install cython
-          pip install .[tests]
+          python -m pip install cython
+          python -m pip install '.[tests]'
+
       - name: Run tests
-        run: python setup.py test -v
+        run: pytest --verbose energyflow/tests/


### PR DESCRIPTION
* Add pull request, schedule, and workflow dispatch triggers for CI.
* Add concurrency limits.
* Use pytest CLI API.
* Remove environment settings that aren't used.
* Drop Python 3.7 from tests as not supported on all platforms and now EOL.