### PR TITLE
fix: Add support for NumPy 2.0

### DIFF
--- a/energyflow/algorithms/einsumfunc.py
+++ b/energyflow/algorithms/einsumfunc.py
@@ -12,9 +12,13 @@ from __future__ import division, absolute_import, print_function
 
 import itertools
 
-from numpy.compat import basestring
-from numpy.core.multiarray import c_einsum
-from numpy.core.numeric import asarray, asanyarray, result_type, tensordot, dot
+try:
+    from numpy._core.multiarray import c_einsum
+    from numpy._core.numeric import asanyarray, tensordot
+except ModuleNotFoundError:
+    # numpy v1.x
+    from numpy.core.multiarray import c_einsum
+    from numpy.core.numeric import asanyarray, tensordot
 
 __all__ = ['einsum', 'einsum_path']
 
@@ -519,7 +523,7 @@ def _parse_einsum_input(operands):
     if len(operands) == 0:
         raise ValueError("No input operands")
 
-    if isinstance(operands[0], basestring):
+    if isinstance(operands[0], str):
         subscripts = operands[0].replace(" ", "")
         operands = [asanyarray(v) for v in operands[1:]]
 
@@ -773,7 +777,7 @@ def einsum_path(*operands, **kwargs):
     memory_limit = None
 
     # No optimization or a named path algorithm
-    if (path_type is False) or isinstance(path_type, basestring):
+    if (path_type is False) or isinstance(path_type, str):
         pass
 
     # Given an explicit path
@@ -781,7 +785,7 @@ def einsum_path(*operands, **kwargs):
         pass
 
     # Path tuple with memory limit
-    elif ((len(path_type) == 2) and isinstance(path_type[0], basestring) and
+    elif ((len(path_type) == 2) and isinstance(path_type[0], str) and
             isinstance(path_type[1], (int, float))):
         memory_limit = int(path_type[1])
         path_type = path_type[0]

--- a/energyflow/efm.py
+++ b/energyflow/efm.py
@@ -41,7 +41,12 @@ from operator import itemgetter
 import sys
 
 import numpy as np
-from numpy.core.multiarray import c_einsum
+
+try:
+    from numpy._core.multiarray import c_einsum
+except ModuleNotFoundError:
+    # numpy v1.x
+    from numpy.core.multiarray import c_einsum
 
 from energyflow.algorithms import einsum
 from energyflow.base import EFMBase

--- a/energyflow/obs.py
+++ b/energyflow/obs.py
@@ -21,7 +21,12 @@ from __future__ import absolute_import, division, print_function
 from abc import abstractmethod
 
 import numpy as np
-from numpy.core.multiarray import c_einsum
+
+try:
+    from numpy._core.multiarray import c_einsum
+except ModuleNotFoundError:
+    # numpy v1.x
+    from numpy.core.multiarray import c_einsum
 
 from energyflow.base import SingleEnergyCorrelatorBase
 from energyflow.utils import import_fastjet, transfer


### PR DESCRIPTION
Resolves #35

* Remove use of numpy.compat as `basestring` is `str` in Python 3.

  > DeprecationWarning: `np.compat`, which was used during the Python 2 to 3 transition, is deprecated since 1.26.0, and will be removed

* Default to using NumPy 2.0 numpy._core API

On `ModuleNotFoundError` fallback to the NumPy v1.X `numpy.core` API.

Running locally this passes the tests

<details>
<summary>With numpy v1.25.2:</summary>

```console
$ pytest energyflow/tests/
================================================================================================== test session starts ===================================================================================================
platform linux -- Python 3.11.7, pytest-8.1.1, pluggy-1.4.0
rootdir: /home/feickert/Code/GitHub/forks/EnergyFlow
configfile: pytest.ini
collected 2776 items                                                                                                                                                                                                     

energyflow/tests/test_algorithms.py ..........                                                                                                                                                                     [  0%]
energyflow/tests/test_archs.py XXXXXXXXXXXXXXXX....................................................................XXXXXXXXXXXXXXXX............................................................                    [  6%]
energyflow/tests/test_efm.py ..................................................................................................................................................................                    [ 11%]
energyflow/tests/test_efp.py ..................................................ss......ss......ss......s.......s.......s.......s.......s.......s.ssssssssssssssss......s.ssssssssssssssss......s.................. [ 18%]
.ssssss..................ssssss..................ssssss..................sss.....................sss.....................sss.....................sss.....................sss.....................sss...sssssssssss [ 26%]
sssssssssssssssssssssssssssssssssssss..................sss...ssssssssssssssssssssssssssssssssssssssssssssssss..................sss................................................................................ [ 33%]
.................................................                                                                                                                                                                  [ 35%]
energyflow/tests/test_emd.py ..................................................................................................................................................................................... [ 41%]
.................................................................................................................................................................................................................. [ 49%]
...................s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s......................................................................................................................... [ 57%]
.........................s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..s..ssss....ssss..................................................................................................... [ 64%]
.....................................                                                                                                                                                                              [ 65%]
energyflow/tests/test_gen.py s..                                                                                                                                                                                   [ 66%]
energyflow/tests/test_measure.py ................................................................................................................................................................................. [ 72%]
...................................................ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss............. [ 79%]
.ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............ss..............s [ 87%]
s..............ss..............ss..............ss..............ss..............ss..............ss......................                                                                                            [ 91%]
energyflow/tests/test_obs.py ..................ssss..ssss..                                                                                                                                                        [ 92%]
energyflow/tests/test_utils.py ................................................................................................................................................................................... [ 99%]
..................                                                                                                                                                                                                 [100%]

==================================================================================================== warnings summary ====================================================================================================
energyflow/tests/test_archs.py::test_EFN_modelcheck[efn_test_model.h5-True-False-modelcheck_opts0]
energyflow/tests/test_archs.py::test_EFN_modelcheck[efn_test_model.h5-True-False-modelcheck_opts1]
energyflow/tests/test_archs.py::test_EFN_modelcheck[efn_test_model.h5-False-False-modelcheck_opts0]
energyflow/tests/test_archs.py::test_EFN_modelcheck[efn_test_model.h5-False-False-modelcheck_opts1]
  /home/feickert/.pyenv/versions/energyflow-dev/lib/python3.11/site-packages/keras/src/engine/training.py:3103: UserWarning: You are saving your model as an HDF5 file via `model.save()`. This file format is considered legacy. We recommend using instead the native Keras format, e.g. `model.save('my_model.keras')`.
    saving_api.save_model(

energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-1]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-2]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-5]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-10]
  /home/feickert/Code/GitHub/forks/EnergyFlow/energyflow/emd.py:334: UserWarning: Keyword argument 'phi_col' has no effect on `emds`. Use `emds_pot` if you need previous functionality.
    warnings.warn("Keyword argument '{}' has no effect on `emds`.".format(k)

energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-1]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-2]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-5]
energyflow/tests/test_emd.py::test_periodic_phi[wasserstein-2-10]
  /home/feickert/Code/GitHub/forks/EnergyFlow/energyflow/emd.py:169: UserWarning: Keyword argument 'phi_col' has no effect on `emd`. Use `emd_pot` if you need previous functionality.
    warnings.warn("Keyword argument '{}' has no effect on `emd`.".format(k)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 2435 passed, 309 skipped, 32 xpassed, 12 warnings in 334.02s (0:05:34) =========================================================================
```

</details>