### PR TITLE
ci: Build wheels in separate workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,12 +34,6 @@ jobs:
       - name: Build SDist and wheel
         run: pipx run build
 
-      - name: Upload to GitHub
-        uses: actions/upload-artifact@v4
-        with:
-          name: Packages
-          path: dist/*
-
       - name: Check metadata
         run: pipx run twine check --strict dist/*
 
@@ -48,3 +42,9 @@ jobs:
 
       - name: List contents of wheel
         run: python -m zipfile --list dist/*.whl
+
+      - name: Upload to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: Packages
+          path: dist/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,7 +26,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
 
       - name: Display Python version
         run: python --version

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,0 +1,44 @@
+name: Builds
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  # Run weekly at 1:23 UTC
+  schedule:
+  - cron: '23 1 * * 0'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+
+      - name: Display Python version
+        run: python --version
+
+      - name: Build SDist and wheel
+        run: pipx run build
+
+      - name: Upload to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: Packages
+          path: dist/*
+
+      - name: Check metadata
+        run: pipx run twine check dist/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -41,4 +41,4 @@ jobs:
           path: dist/*
 
       - name: Check metadata
-        run: pipx run twine check dist/*
+        run: pipx run twine check --strict dist/*

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -42,3 +42,9 @@ jobs:
 
       - name: Check metadata
         run: pipx run twine check --strict dist/*
+
+      - name: List contents of sdist
+        run: python -m tarfile --list dist/*.tar.gz
+
+      - name: List contents of wheel
+        run: python -m zipfile --list dist/*.whl


### PR DESCRIPTION
Addresses part of #31:

> - [ ] Split the CI components from the wheel building in CI
> c.f. https://github.com/thaler-lab/Wasserstein/pull/8
> - [ ] Have the wheel building workflows run and [upload the wheels to GitHub Actions as an artifact](https://learn.scientific-python.org/development/guides/gha-wheels/#the-core-job-3-main-oss)