### PR TITLE
docs: Update to 'thaler-lab' GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ EnergyFlow is a Python package that computes Energy Flow Polynomials (EFPs) as d
 #### Installation
 
 To install EnergyFlow with pip, simply execute:
-```sh
-pip3 install energyflow
+
+```console
+python -m pip install energyflow
 ```
 
 #### Documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EnergyFlow
-[![Build Status](https://travis-ci.com/pkomiske/EnergyFlow.svg?branch=master)](https://travis-ci.com/pkomiske/EnergyFlow)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master)
+[![Build Status](https://github.com/thaler-lab/EnergyFlow/actions/workflows/test-energyflow.yml/badge.svg)](https://github.com/thaler-lab/EnergyFlow/actions/workflows/test-energyflow.yml?query=branch%3Amaster)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master)
 
 EnergyFlow is a Python package that computes Energy Flow Polynomials (EFPs) as defined in Ref. [1], implements Energy Flow Networks (EFNs) and Particle Flow Networks (PFNs) as defined in Ref. [2], computes Energy Mover's Distances as defined in Ref. [3], and provides access to some particle physics [datasets hosted on Zenodo](https://zenodo.org/search?page=1&size=20&q=komiske&sort=title) including the jet datasets in MOD HDF5 format used in Ref. [4].
 

--- a/demos/EnergyFlow Demo.ipynb
+++ b/demos/EnergyFlow Demo.ipynb
@@ -220,7 +220,7 @@
     "\n",
     "If we are interested in using the spanning properties of EFPs, we typically want to compute large numbers of EFPs. The EnergyFlow package does the heavy lifting for you! It contains information about all multigraphs with up to 10 edges, which can be easily and intuitively accessed using `EFPSet`.\n",
     "\n",
-    "Relevant graph quantities which can easily be used to select a set of multigraphs are summarized below. More options are available: for a full list see the [documentation](https://pkomiske.github.io/EnergyFlow/).\n",
+    "Relevant graph quantities which can easily be used to select a set of multigraphs are summarized below. More options are available: for a full list see the [documentation](https://thaler-lab.github.io/EnergyFlow/).\n",
     "\n",
     "`n` : Number of vertices in the multigraph.\n",
     "\n",
@@ -317,7 +317,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To study the properties of an individual EFP within `EFPSet` we can easily do this using `specs` and `graphs`. Suppose we are interested in the 95th EFP. We can find out its graph and all of its relevant information simply with the following syntax. Here we show only a subset of all the information that specs provides about an EFP: for a full list see the [documentation](https://pkomiske.github.io/EnergyFlow/)."
+    "To study the properties of an individual EFP within `EFPSet` we can easily do this using `specs` and `graphs`. Suppose we are interested in the 95th EFP. We can find out its graph and all of its relevant information simply with the following syntax. Here we show only a subset of all the information that specs provides about an EFP: for a full list see the [documentation](https://thaler-lab.github.io/EnergyFlow/)."
    ]
   },
   {
@@ -409,7 +409,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And that's it! Now you should be able to specify any EFP (i.e. multigraph) or set of EFPs that you want to comput with `EFP` or `EFPSet`, compute them on a set of events with `compute` or `batch_compute`, and study the results with `specs` and `graphs`! As always, see the [documentation](https://pkomiske.github.io/EnergyFlow/) for a full description of the EnergyFlow package."
+    "And that's it! Now you should be able to specify any EFP (i.e. multigraph) or set of EFPs that you want to comput with `EFP` or `EFPSet`, compute them on a set of events with `compute` or `batch_compute`, and study the results with `specs` and `graphs`! As always, see the [documentation](https://thaler-lab.github.io/EnergyFlow/) for a full description of the EnergyFlow package."
    ]
   }
  ],

--- a/docs/404.html
+++ b/docs/404.html
@@ -154,7 +154,7 @@
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
 

--- a/docs/demos/index.html
+++ b/docs/demos/index.html
@@ -156,31 +156,31 @@
 <h2 id="energyflow-demo">EnergyFlow Demo</h2>
 <p>The EnergyFlow Demo provides an introduction to using EnergyFlow to compute Energy Flow Polynomials.</p>
 <ul>
-<li><a href="https://github.com/pkomiske/EnergyFlow/blob/master/demos/EnergyFlow%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
-<li><a href="https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EnergyFlow%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
+<li><a href="https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EnergyFlow%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
+<li><a href="https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EnergyFlow%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
 </ul>
 <h2 id="emd-demo">EMD Demo</h2>
 <p>The EMD Demo provides an introduction to using EnergyFlow for computing the Energy Mover's Distance (EMD) between jets.</p>
 <ul>
-<li><a href="https://github.com/pkomiske/EnergyFlow/blob/master/demos/EMD%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
-<li><a href="https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EMD%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
+<li><a href="https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EMD%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
+<li><a href="https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EMD%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
 </ul>
 <h2 id="mod-jet-demo">MOD Jet Demo</h2>
 <p>The MOD Jet Demo provides an introduction to using CMS Open Data in the MOD HDF5 format via EnergyFlow. Jets from the <a href="http://doi.org/10.7483/OPENDATA.CMS.UP77.P6PQ">CMS 2011A Jet Primary Dataset</a> have been processed into this easy-to-use format and are <a href="https://doi.org/10.5281/zenodo.3340205">available on Zenodo</a> along with corresponding simulated datasets.</p>
 <ul>
-<li><a href="https://github.com/pkomiske/EnergyFlow/blob/master/demos/MOD%20Jet%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
-<li><a href="https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/MOD%20Jet%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
+<li><a href="https://github.com/thaler-lab/EnergyFlow/blob/master/demos/MOD%20Jet%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
+<li><a href="https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/MOD%20Jet%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
 </ul>
 <h2 id="efm-demo">EFM Demo</h2>
 <p>The EFM Demo provides an introduction to Energy Flow Moments to compute EFPs and verify linear relations among them.</p>
 <ul>
-<li><a href="https://github.com/pkomiske/EnergyFlow/blob/master/demos/EFM%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
-<li><a href="https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EFM%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
+<li><a href="https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EFM%20Demo.ipynb">View or download</a> the notebook from GitHub</li>
+<li><a href="https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EFM%20Demo.ipynb"><img alt="Binder" src="https://mybinder.org/badge_logo.svg" /></a></li>
 </ul>
 <h2 id="counting-leafless-multigaphs-with-nauty">Counting Leafless Multigaphs with Nauty</h2>
 <p>Though not demonstrating features of the EnergyFlow library, this script uses the graph program <a href="http://pallini.di.uniroma1.it/">Nauty</a> to count leafless multigraphs, a task which relates to EFMs as described in <a href="https://arxiv.org/abs/1911.04491">1911.04491</a>. To run this script, first <a href="http://pallini.di.uniroma1.it/nauty26r12.tar.gz">download Nauty</a> and compile it. Then point the Python script to the Nauty installation directory. Note that running with <code>-d 16</code> has been known to take half a month.</p>
 <ul>
-<li><a href="https://github.com/pkomiske/EnergyFlow/blob/master/demos/count_leafless_multigraphs_nauty.py">View or download</a> the script from GitHub</li>
+<li><a href="https://github.com/thaler-lab/EnergyFlow/blob/master/demos/count_leafless_multigraphs_nauty.py">View or download</a> the script from GitHub</li>
 </ul>
 
             </div>
@@ -219,7 +219,7 @@
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../installation/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/archs/index.html
+++ b/docs/docs/archs/index.html
@@ -867,7 +867,7 @@ convergence parameter.</li>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../../news/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/datasets/index.html
+++ b/docs/docs/datasets/index.html
@@ -1045,7 +1045,7 @@ prior to redownloading.</p>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../archs/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/efm/index.html
+++ b/docs/docs/efm/index.html
@@ -518,7 +518,7 @@ where the order is the same as <code>sorted_efms</code>.</p>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../emd/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/efp/index.html
+++ b/docs/docs/efp/index.html
@@ -781,7 +781,7 @@ each column.</p>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../efm/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/emd/index.html
+++ b/docs/docs/emd/index.html
@@ -154,7 +154,7 @@
 
                 <h1 id="energy-movers-distance">Energy Mover's Distance</h1>
 <video width="100%" autoplay loop controls>
-    <source src="https://github.com/pkomiske/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
+    <source src="https://github.com/thaler-lab/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
             type="video/mp4">
 </video>
 <p><br></p>
@@ -163,7 +163,7 @@ a metric between particle collider events introduced in <a href="https://
 arxiv.org/abs/1902.02346">1902.02346</a>. This submodule contains convenient functions for
 computing EMDs between individual events and collections of events. The core of
 the computation is handled by either the <a href="https://github.com/
-pkomiske/Wasserstein">Wasserstein</a> library or the <a href="https://
+thaler-lab/Wasserstein">Wasserstein</a> library or the <a href="https://
 pot.readthedocs.io">Python Optimal Transport (POT)</a> library, one of which must be installed in order to use this
 submodule.</p>
 <p>From Eqs. (1.2) and (1.3) in <a href="https://arxiv.org/abs/2004.04159">2004.04159</a>, the
@@ -712,7 +712,7 @@ and particle j in <code>ev1</code>.</li>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../datasets/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/gen/index.html
+++ b/docs/docs/gen/index.html
@@ -280,7 +280,7 @@ and the columns represent the quantities indicated by <code>cols</code>.</p>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../measures/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/measures/index.html
+++ b/docs/docs/measures/index.html
@@ -337,7 +337,7 @@ context.)</li>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../efp/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/obs/index.html
+++ b/docs/docs/obs/index.html
@@ -328,7 +328,7 @@ and <code>1</code>.</li>
 <h2 id="d2">D2</h2>
 <p>Ratio of EFPs (specifically, energy correlation functions) designed to
 tag two prong signals. In graphs, the formula is:</p>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/D2.png"
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/D2.png"
 class="obs_center" width="20%"/></p>
 <p>For additional information, see the <a href="https://arxiv.org/
 abs/1409.6298">original paper</a>.</p>
@@ -449,7 +449,7 @@ use as many processes as there are CPUs on the machine.</li>
 <h2 id="c2">C2</h2>
 <p>Ratio of Energy Correlation Functions designed to tag two prong signals.
 In graphs, the formula is:</p>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/C2.png"
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C2.png"
 class="obs_center" width="20%"/></p>
 <p>For additional information, see the <a href="https://arxiv.org/
 abs/1305.0007">original paper</a>.</p>
@@ -570,7 +570,7 @@ use as many processes as there are CPUs on the machine.</li>
 <h2 id="c3">C3</h2>
 <p>Ratio of Energy Correlation Functions designed to tag three prong
 signals. In graphs, the formula is:</p>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/C3.png"
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C3.png"
 class="obs_center" width="30%"/></p>
 <p>For additional information, see the <a href="https://arxiv.org/
 abs/1305.0007">original paper</a>.</p>
@@ -720,7 +720,7 @@ use as many processes as there are CPUs on the machine.</li>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../gen/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/docs/utils/index.html
+++ b/docs/docs/utils/index.html
@@ -1408,7 +1408,7 @@ obs/#zg_from_pj"><span><span class="MathJax_Preview">z_g</span><script type="mat
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../obs/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -1228,7 +1228,7 @@ anim.save('energyflowanimation.mp4', fps=fps, dpi=200)
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../demos/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/faqs/index.html
+++ b/docs/faqs/index.html
@@ -422,11 +422,11 @@ doi.org/10.5281/zenodo.3341772"><img alt="DOI" src="/img/zenodo.3341772.svg" /><
 <p><a href="http://www.numpy.org">NumPy</a> is a highly-optimized Python library written in C that provides all of the tools required to efficiently compute the EFPs. Libraries like NumPy take advantage of optimizations that the physicist-programmer typically does not, such as architecture-optimized libraries like BLAS or LAPACK and low-level features such as SSE/AVX instructions.</p>
 <p>Beyond just computing EFPs, EnergyFlow makes use of other libraries written in python including <a href="https://keras.io/">Keras</a> and <a href="https://scikit-learn.org/">scikit-learn</a> for the architecture implementations, <a href="https://pot.readthedocs.io/en/stable/">POT</a> and <a href="https://www.scipy.org/">SciPy</a> for EMD computations, and <a href="https://matplotlib.org/index.html">matplotlib</a> for the examples.</p>
 <h2 id="can-i-contribute-to-the-code">Can I contribute to the code?</h2>
-<p>All of our code is open source and hosted on <a href="https://www.github.com/pkomiske/EnergyFlow/">GitHub</a>. We welcome additional contributors, and if you are interested in getting involved please contact us directly. Contact information is included in the relevant Energy Flow papers and our GitHub repository.</p>
+<p>All of our code is open source and hosted on <a href="https://www.github.com/thaler-lab/EnergyFlow/">GitHub</a>. We welcome additional contributors, and if you are interested in getting involved please contact us directly. Contact information is included in the relevant Energy Flow papers and our GitHub repository.</p>
 <h2 id="how-do-i-report-an-issue">How do I report an issue?</h2>
-<p>Please let us know of any issues you encounter as soon as possible by creating a GitHub <a href="https://github.com/pkomiske/EnergyFlow">Issue</a>.</p>
+<p>Please let us know of any issues you encounter as soon as possible by creating a GitHub <a href="https://github.com/thaler-lab/EnergyFlow">Issue</a>.</p>
 <h2 id="where-can-i-get-graph-image-files">Where can I get graph image files?</h2>
-<p>Image files for all connected multigraphs with up to 7 edges in the EFP style are available as PDF files <a href="https://github.com/pkomiske/EnergyFlow/tree/images/graphs">here</a>. You are free to use them with the proper attribution.</p>
+<p>Image files for all connected multigraphs with up to 7 edges in the EFP style are available as PDF files <a href="https://github.com/thaler-lab/EnergyFlow/tree/images/graphs">here</a>. You are free to use them with the proper attribution.</p>
 
             </div>
           </div>
@@ -464,7 +464,7 @@ doi.org/10.5281/zenodo.3341772"><img alt="DOI" src="/img/zenodo.3341772.svg" /><
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../examples/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -145,8 +145,8 @@
             <div class="section">
 
                 <h1 id="welcome-to-energyflow">Welcome to EnergyFlow</h1>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/></p>
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/></p>
 <h2 id="features">Features</h2>
 <p>EnergyFlow is a Python package containing a suite of particle physics tools:</p>
 <ul>
@@ -172,7 +172,7 @@
 <br><br></li>
 <li><a href="examples">Detailed Examples</a>: Examples showcasing EFPs, EFNs, PFNs, EMDs, and more.</li>
 </ul>
-<p>The current version is <code>1.3.3</code>. Changes are summarized in the <a href="releases">Release Notes</a>. Using the most up-to-date version is recommended. As of version <code>0.7.0</code>, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on <a href="https://github.com/pkomiske/EnergyFlow">GitHub</a>.</p>
+<p>The current version is <code>1.3.3</code>. Changes are summarized in the <a href="releases">Release Notes</a>. Using the most up-to-date version is recommended. As of version <code>0.7.0</code>, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on <a href="https://github.com/thaler-lab/EnergyFlow">GitHub</a>.</p>
 <p>Get started by <a href="installation">installing EnergyFlow</a>, <a href="demos">exploring the demos</a>, and <a href="examples">running the examples</a>!</p>
 <h2 id="authors">Authors</h2>
 <p>EnergyFlow is developed and maintained by:</p>
@@ -191,7 +191,7 @@
 <p>[6] A. Andreassen, P. T. Komiske, E. M. Metodiev, B. Nachman, and J. Thaler, <em>OmniFold: A Method to Simultaneously Unfold All Observables</em>, <a href="https://doi.org/10.1103/PhysRevLett.124.182001">Phys. Rev. Lett. <strong>124</strong> (2020) 182001</a> [<a href="https://arxiv.org/abs/1911.09107">1911.09107</a>].</p>
 <p>[7] P. T. Komiske, E. M. Metodiev, and J. Thaler, <em>The Hidden Geometry of Particle Collisions</em>, <a href="https://doi.org/10.1007/JHEP07(2020)006">JHEP <strong>07</strong> (2020) 006</a> [<a href="https://arxiv.org/abs/2004.04159">2004.04159</a>].</p>
 <h2 id="copyright">Copyright</h2>
-<p>EnergyFlow is licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPLv3</a>. See the <a href="https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE">LICENSE</a> for detailed copyright information. EnergyFlow uses a customized <code>einsumfunc.py</code> from the <a href="https://github.com/numpy/numpy">NumPy GitHub</a> repository as well as a few functions relating to downloading files copied from the <a href="https://github.com/keras-team/keras">Keras GitHub</a> repository. The copyrights for these parts of the code are attributed to their respective owners in the <a href="https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE">LICENSE</a> file.</p>
+<p>EnergyFlow is licensed under <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPLv3</a>. See the <a href="https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE">LICENSE</a> for detailed copyright information. EnergyFlow uses a customized <code>einsumfunc.py</code> from the <a href="https://github.com/numpy/numpy">NumPy GitHub</a> repository as well as a few functions relating to downloading files copied from the <a href="https://github.com/keras-team/keras">Keras GitHub</a> repository. The copyrights for these parts of the code are attributed to their respective owners in the <a href="https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE">LICENSE</a> file.</p>
 
             </div>
           </div>
@@ -227,7 +227,7 @@
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -148,7 +148,7 @@
 <p>The EnergyFlow package is written in pure Python and the core depends only on <code>NumPy</code>, the fundamental package for scientific computing with Python, <code>six</code>, which is a lightweight module to patch some inconvenient differences between Python 2 and Python 3, and <code>h5py</code>, which is used to interface with HDF5 files. The extra features require additional packages as specified below:</p>
 <ul>
 <li>Architectures: <a href="https://www.tensorflow.org">Tensorflow</a>, <a href="https://scikit-learn.org">scikit-learn</a>.</li>
-<li>EMD: <a href="https://pkomiske.github.io/Wasserstein">Wasserstein</a> or <a href="https://pythonot.github.io/">POT</a></li>
+<li>EMD: <a href="https://thaler-lab.github.io/Wasserstein">Wasserstein</a> or <a href="https://pythonot.github.io/">POT</a></li>
 <li>Multigraph Generation: <a href="http://igraph.org/redirect.html">iGraph</a></li>
 </ul>
 <p>The EnergyFlow package is designed to work with Python 3.6 and higher, though it may work with previous versions as well, including Python 2.7. These can be installed from <a href="https://www.python.org/downloads/">here</a>. A recent version of Python 3 is highly recommended, ideally 3.6 or higher.</p>
@@ -193,7 +193,7 @@
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href=".." style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -148,7 +148,7 @@
 
                 <h1 id="news">News</h1>
 <h2 id="nyt-on-the-theory-of-everything">NYT on the Theory of Everything</h2>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/24SCI-AIPHYSICS-superJumbo.jpg" width="75%"/>
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/24SCI-AIPHYSICS-superJumbo.jpg" width="75%"/>
 <br/>
 Image: Alex Eben Meyer</p>
 <p><a href="https://www.nytimes.com/2020/11/23/science/artificial-intelligence-ai-physics-theory.html"><strong>Can a Computer Devise a Theory of Everything?</strong></a><br />
@@ -162,7 +162,7 @@ Image: Alex Eben Meyer</p>
 </li>
 </ul>
 <h2 id="iaifi-announcement">IAIFI Announcement</h2>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/iaifi-pressimage-smaller.jpg" width="85%"/>
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/iaifi-pressimage-smaller.jpg" width="85%"/>
 <br/>
 Image: IAIFI</p>
 <p>The <a href="https://www.nsf.gov/news/special_reports/announcements/082620.jsp">NSF has announced</a> the creation of the <a href="https://iaifi.org/">Institute for Artificial Intelligence and Fundamental Interactions (IAIFI)</a> with an investment of $20 million over five years. IAIFI is a partnership between MIT, Harvard, Northeastern, and Tufts, and will be based at MIT and directed by Jesse Thaler.</p>
@@ -175,7 +175,7 @@ Image: IAIFI</p>
 <p><a href="https://news.northeastern.edu/2020/08/26/why-you-need-a-computer-to-understand-strings-and-knots/"><strong>Why You Need a Computer to Understand Strings and Knots</strong></a><br />
 <em>News@Northeastern</em>, Emily Arntsen. August 26, 2020.</p>
 <h2 id="emd-media-coverage">EMD Media Coverage</h2>
-<p><img src="https://github.com/pkomiske/EnergyFlow/raw/images/MIT-Particle-Networking.jpg" width="80%"/>
+<p><img src="https://github.com/thaler-lab/EnergyFlow/raw/images/MIT-Particle-Networking.jpg" width="80%"/>
 <br/>
 Image: Chelsea Turner, MIT</p>
 <p><a href="http://news.mit.edu/2019/new-physics-anomalous-particles-0726"><strong>Seeking new physics, scientists borrow from social networks</strong></a><br />
@@ -225,7 +225,7 @@ Image: Chelsea Turner, MIT</p>
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../releases/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -390,7 +390,7 @@ the <a href="https://pot.readthedocs.io">Python Optimal Transport</a> library an
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
         <span><a href="../faqs/" style="color: #fcfcfc;">&laquo; Previous</a></span>

--- a/docs/search.html
+++ b/docs/search.html
@@ -165,7 +165,7 @@
   <div class="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
 
-          <a href="https://github.com/pkomiske/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
+          <a href="https://github.com/thaler-lab/EnergyFlow" class="fa fa-github" style="float: left; color: #fcfcfc"> GitHub</a>
 
 
 

--- a/energyflow/emd.py
+++ b/energyflow/emd.py
@@ -1,7 +1,7 @@
 r"""# Energy Mover's Distance
 
 <video width="100%" autoplay loop controls>
-    <source src="https://github.com/pkomiske/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
+    <source src="https://github.com/thaler-lab/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
             type="video/mp4">
 </video>
 <br>
@@ -11,7 +11,7 @@ a metric between particle collider events introduced in [1902.02346](https://
 arxiv.org/abs/1902.02346). This submodule contains convenient functions for
 computing EMDs between individual events and collections of events. The core of
 the computation is handled by either the [Wasserstein](https://github.com/
-pkomiske/Wasserstein) library or the [Python Optimal Transport (POT)](https://
+thaler-lab/Wasserstein) library or the [Python Optimal Transport (POT)](https://
 pot.readthedocs.io) library, one of which must be installed in order to use this
 submodule.
 

--- a/energyflow/obs.py
+++ b/energyflow/obs.py
@@ -46,7 +46,7 @@ class D2(SingleEnergyCorrelatorBase):
     """Ratio of EFPs (specifically, energy correlation functions) designed to
     tag two prong signals. In graphs, the formula is:
 
-    <img src="https://github.com/pkomiske/EnergyFlow/raw/images/D2.png"
+    <img src="https://github.com/thaler-lab/EnergyFlow/raw/images/D2.png"
     class="obs_center" width="20%"/>
 
     For additional information, see the [original paper](https://arxiv.org/
@@ -125,7 +125,7 @@ class C2(SingleEnergyCorrelatorBase):
     """Ratio of Energy Correlation Functions designed to tag two prong signals.
     In graphs, the formula is:
 
-    <img src="https://github.com/pkomiske/EnergyFlow/raw/images/C2.png"
+    <img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C2.png"
     class="obs_center" width="20%"/>
 
     For additional information, see the [original paper](https://arxiv.org/
@@ -204,7 +204,7 @@ class C3(SingleEnergyCorrelatorBase):
     """Ratio of Energy Correlation Functions designed to tag three prong
     signals. In graphs, the formula is:
 
-    <img src="https://github.com/pkomiske/EnergyFlow/raw/images/C3.png"
+    <img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C3.png"
     class="obs_center" width="30%"/>
 
     For additional information, see the [original paper](https://arxiv.org/

--- a/energyflow/utils/data_utils.py
+++ b/energyflow/utils/data_utils.py
@@ -60,7 +60,7 @@ def get_examples(path='~/.energyflow', which='all', overwrite=False):
             which = [which]
         examples = all_examples.intersection(which)
 
-    base_url = 'https://github.com/pkomiske/EnergyFlow/raw/master/examples/'
+    base_url = 'https://github.com/thaler-lab/EnergyFlow/raw/master/examples/'
     cache_dir = os.path.expanduser(path)
 
     # get each example

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: EnergyFlow
 site_url: https://energyflow.network
 site_description: Documentation for EnergyFlow
 site_author: Patrick T. Komiske III, Eric M. Metodiev
-repo_url: https://github.com/pkomiske/EnergyFlow
+repo_url: https://github.com/thaler-lab/EnergyFlow
 copyright: Copyright (C) 2017-2024 EnergyFlow Authors
 edit_uri: ""
 

--- a/mkdocs/sources/demos.md
+++ b/mkdocs/sources/demos.md
@@ -8,32 +8,32 @@ For more computationally intensive tasks, such as training EFNs/PFNs or other ne
 
 The EnergyFlow Demo provides an introduction to using EnergyFlow to compute Energy Flow Polynomials.
 
-- [View or download](https://github.com/pkomiske/EnergyFlow/blob/master/demos/EnergyFlow%20Demo.ipynb) the notebook from GitHub
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EnergyFlow%20Demo.ipynb)
+- [View or download](https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EnergyFlow%20Demo.ipynb) the notebook from GitHub
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EnergyFlow%20Demo.ipynb)
 
 ## EMD Demo
 
 The EMD Demo provides an introduction to using EnergyFlow for computing the Energy Mover's Distance (EMD) between jets.
 
-- [View or download](https://github.com/pkomiske/EnergyFlow/blob/master/demos/EMD%20Demo.ipynb) the notebook from GitHub
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EMD%20Demo.ipynb)
+- [View or download](https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EMD%20Demo.ipynb) the notebook from GitHub
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EMD%20Demo.ipynb)
 
 ## MOD Jet Demo
 
 The MOD Jet Demo provides an introduction to using CMS Open Data in the MOD HDF5 format via EnergyFlow. Jets from the [CMS 2011A Jet Primary Dataset](http://doi.org/10.7483/OPENDATA.CMS.UP77.P6PQ) have been processed into this easy-to-use format and are [available on Zenodo](https://doi.org/10.5281/zenodo.3340205) along with corresponding simulated datasets.
 
-- [View or download](https://github.com/pkomiske/EnergyFlow/blob/master/demos/MOD%20Jet%20Demo.ipynb) the notebook from GitHub
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/MOD%20Jet%20Demo.ipynb)
+- [View or download](https://github.com/thaler-lab/EnergyFlow/blob/master/demos/MOD%20Jet%20Demo.ipynb) the notebook from GitHub
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/MOD%20Jet%20Demo.ipynb)
 
 ## EFM Demo
 
 The EFM Demo provides an introduction to Energy Flow Moments to compute EFPs and verify linear relations among them.
 
-- [View or download](https://github.com/pkomiske/EnergyFlow/blob/master/demos/EFM%20Demo.ipynb) the notebook from GitHub
-- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pkomiske/EnergyFlow/master?filepath=demos/EFM%20Demo.ipynb)
+- [View or download](https://github.com/thaler-lab/EnergyFlow/blob/master/demos/EFM%20Demo.ipynb) the notebook from GitHub
+- [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/thaler-lab/EnergyFlow/master?filepath=demos/EFM%20Demo.ipynb)
 
 ## Counting Leafless Multigaphs with Nauty
 
 Though not demonstrating features of the EnergyFlow library, this script uses the graph program [Nauty](http://pallini.di.uniroma1.it/) to count leafless multigraphs, a task which relates to EFMs as described in [1911.04491](https://arxiv.org/abs/1911.04491). To run this script, first [download Nauty](http://pallini.di.uniroma1.it/nauty26r12.tar.gz) and compile it. Then point the Python script to the Nauty installation directory. Note that running with `-d 16` has been known to take half a month.
 
-- [View or download](https://github.com/pkomiske/EnergyFlow/blob/master/demos/count_leafless_multigraphs_nauty.py) the script from GitHub
+- [View or download](https://github.com/thaler-lab/EnergyFlow/blob/master/demos/count_leafless_multigraphs_nauty.py) the script from GitHub

--- a/mkdocs/sources/docs/emd.md
+++ b/mkdocs/sources/docs/emd.md
@@ -1,7 +1,7 @@
 # Energy Mover's Distance
 
 <video width="100%" autoplay loop controls>
-    <source src="https://github.com/pkomiske/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
+    <source src="https://github.com/thaler-lab/EnergyFlow/raw/images/CMS2011AJets_EventSpaceTriangulation.mp4"
             type="video/mp4">
 </video>
 <br>
@@ -11,7 +11,7 @@ a metric between particle collider events introduced in [1902.02346](https://
 arxiv.org/abs/1902.02346). This submodule contains convenient functions for
 computing EMDs between individual events and collections of events. The core of
 the computation is handled by either the [Wasserstein](https://github.com/
-pkomiske/Wasserstein) library or the [Python Optimal Transport (POT)](https://
+thaler-lab/Wasserstein) library or the [Python Optimal Transport (POT)](https://
 pot.readthedocs.io) library, one of which must be installed in order to use this
 submodule.
 

--- a/mkdocs/sources/docs/obs.md
+++ b/mkdocs/sources/docs/obs.md
@@ -125,7 +125,7 @@ multiple grooming parameters are to be used.
 Ratio of EFPs (specifically, energy correlation functions) designed to
 tag two prong signals. In graphs, the formula is:
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/D2.png"
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/D2.png"
 class="obs_center" width="20%"/>
 
 For additional information, see the [original paper](https://arxiv.org/
@@ -236,7 +236,7 @@ efpset
 Ratio of Energy Correlation Functions designed to tag two prong signals.
 In graphs, the formula is:
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/C2.png"
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C2.png"
 class="obs_center" width="20%"/>
 
 For additional information, see the [original paper](https://arxiv.org/
@@ -347,7 +347,7 @@ efpset
 Ratio of Energy Correlation Functions designed to tag three prong
 signals. In graphs, the formula is:
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/C3.png"
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/C3.png"
 class="obs_center" width="30%"/>
 
 For additional information, see the [original paper](https://arxiv.org/

--- a/mkdocs/sources/faqs.md
+++ b/mkdocs/sources/faqs.md
@@ -292,12 +292,12 @@ Beyond just computing EFPs, EnergyFlow makes use of other libraries written in p
 
 ## Can I contribute to the code?
 
-All of our code is open source and hosted on [GitHub](https://www.github.com/pkomiske/EnergyFlow/). We welcome additional contributors, and if you are interested in getting involved please contact us directly. Contact information is included in the relevant Energy Flow papers and our GitHub repository.
+All of our code is open source and hosted on [GitHub](https://www.github.com/thaler-lab/EnergyFlow/). We welcome additional contributors, and if you are interested in getting involved please contact us directly. Contact information is included in the relevant Energy Flow papers and our GitHub repository.
 
 ## How do I report an issue?
 
-Please let us know of any issues you encounter as soon as possible by creating a GitHub [Issue](https://github.com/pkomiske/EnergyFlow).
+Please let us know of any issues you encounter as soon as possible by creating a GitHub [Issue](https://github.com/thaler-lab/EnergyFlow).
 
 ## Where can I get graph image files?
 
-Image files for all connected multigraphs with up to 7 edges in the EFP style are available as PDF files [here](https://github.com/pkomiske/EnergyFlow/tree/images/graphs). You are free to use them with the proper attribution.
+Image files for all connected multigraphs with up to 7 edges in the EFP style are available as PDF files [here](https://github.com/thaler-lab/EnergyFlow/tree/images/graphs). You are free to use them with the proper attribution.

--- a/mkdocs/sources/index.md
+++ b/mkdocs/sources/index.md
@@ -1,7 +1,7 @@
 # Welcome to EnergyFlow
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/>
 
 ## Features
 
@@ -30,7 +30,7 @@ The EnergyFlow package also provides easy access to particle phyiscs datasets an
 - [Detailed Examples](examples): Examples showcasing EFPs, EFNs, PFNs, EMDs, and more.
 
 
-The current version is `1.3.3a0`. Changes are summarized in the [Release Notes](releases). Using the most up-to-date version is recommended. As of version `0.7.0`, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on [GitHub](https://github.com/pkomiske/EnergyFlow).
+The current version is `1.3.3a0`. Changes are summarized in the [Release Notes](releases). Using the most up-to-date version is recommended. As of version `0.7.0`, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on [GitHub](https://github.com/thaler-lab/EnergyFlow).
 
 Get started by [installing EnergyFlow](installation), [exploring the demos](demos), and [running the examples](examples)!
 
@@ -63,4 +63,4 @@ EnergyFlow is developed and maintained by:
 
 ## Copyright
 
-EnergyFlow is licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html). See the [LICENSE](https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE) for detailed copyright information. EnergyFlow uses a customized `einsumfunc.py` from the [NumPy GitHub](https://github.com/numpy/numpy) repository as well as a few functions relating to downloading files copied from the [Keras GitHub](https://github.com/keras-team/keras) repository. The copyrights for these parts of the code are attributed to their respective owners in the [LICENSE](https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE) file.
+EnergyFlow is licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html). See the [LICENSE](https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE) for detailed copyright information. EnergyFlow uses a customized `einsumfunc.py` from the [NumPy GitHub](https://github.com/numpy/numpy) repository as well as a few functions relating to downloading files copied from the [Keras GitHub](https://github.com/keras-team/keras) repository. The copyrights for these parts of the code are attributed to their respective owners in the [LICENSE](https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE) file.

--- a/mkdocs/sources/installation.md
+++ b/mkdocs/sources/installation.md
@@ -3,7 +3,7 @@
 The EnergyFlow package is written in pure Python and the core depends only on `NumPy`, the fundamental package for scientific computing with Python, `six`, which is a lightweight module to patch some inconvenient differences between Python 2 and Python 3, and `h5py`, which is used to interface with HDF5 files. The extra features require additional packages as specified below:
 
 - Architectures: [Tensorflow](https://www.tensorflow.org), [scikit-learn](https://scikit-learn.org).
-- EMD: [Wasserstein](https://pkomiske.github.io/Wasserstein) or [POT](https://pythonot.github.io/)
+- EMD: [Wasserstein](https://thaler-lab.github.io/Wasserstein) or [POT](https://pythonot.github.io/)
 - Multigraph Generation: [iGraph](http://igraph.org/redirect.html)
 
 The EnergyFlow package is designed to work with Python 3.6 and higher, though it may work with previous versions as well, including Python 2.7. These can be installed from [here](https://www.python.org/downloads/). A recent version of Python 3 is highly recommended, ideally 3.6 or higher.

--- a/mkdocs/sources/news.md
+++ b/mkdocs/sources/news.md
@@ -2,7 +2,7 @@
 
 ## NYT on the Theory of Everything
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/24SCI-AIPHYSICS-superJumbo.jpg" width="75%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/24SCI-AIPHYSICS-superJumbo.jpg" width="75%"/>
 <br/>
 Image: Alex Eben Meyer
 
@@ -15,7 +15,7 @@ Image: Alex Eben Meyer
 
 ## IAIFI Announcement
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/iaifi-pressimage-smaller.jpg" width="85%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/iaifi-pressimage-smaller.jpg" width="85%"/>
 <br/>
 Image: IAIFI
 
@@ -36,7 +36,7 @@ The [NSF has announced](https://www.nsf.gov/news/special_reports/announcements/0
 
 ## EMD Media Coverage
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/MIT-Particle-Networking.jpg" width="80%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/MIT-Particle-Networking.jpg" width="80%"/>
 <br/>
 Image: Chelsea Turner, MIT
 

--- a/mkdocs/sources/templates/index_template.md
+++ b/mkdocs/sources/templates/index_template.md
@@ -1,7 +1,7 @@
 # Welcome to EnergyFlow
 
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
-<img src="https://github.com/pkomiske/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/QG_256_plain.jpg" width="47.5%"/>
+<img src="https://github.com/thaler-lab/EnergyFlow/raw/images/JetCustom_29522924_24981665_EMD.jpg" width="47.5%"/>
 
 ## Features
 
@@ -30,7 +30,7 @@ The EnergyFlow package also provides easy access to particle phyiscs datasets an
 - [Detailed Examples](examples): Examples showcasing EFPs, EFNs, PFNs, EMDs, and more.
 
 
-The current version is `{current_version}`. Changes are summarized in the [Release Notes](releases). Using the most up-to-date version is recommended. As of version `0.7.0`, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on [GitHub](https://github.com/pkomiske/EnergyFlow).
+The current version is `{current_version}`. Changes are summarized in the [Release Notes](releases). Using the most up-to-date version is recommended. As of version `0.7.0`, tests have been written covering the majority of the EFP and EMD code. The architectures code is currently tested by running the examples. The source code can be found on [GitHub](https://github.com/thaler-lab/EnergyFlow).
 
 Get started by [installing EnergyFlow](installation), [exploring the demos](demos), and [running the examples](examples)!
 
@@ -63,4 +63,4 @@ EnergyFlow is developed and maintained by:
 
 ## Copyright
 
-EnergyFlow is licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html). See the [LICENSE](https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE) for detailed copyright information. EnergyFlow uses a customized `einsumfunc.py` from the [NumPy GitHub](https://github.com/numpy/numpy) repository as well as a few functions relating to downloading files copied from the [Keras GitHub](https://github.com/keras-team/keras) repository. The copyrights for these parts of the code are attributed to their respective owners in the [LICENSE](https://github.com/pkomiske/EnergyFlow/blob/master/LICENSE) file.
+EnergyFlow is licensed under [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html). See the [LICENSE](https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE) for detailed copyright information. EnergyFlow uses a customized `einsumfunc.py` from the [NumPy GitHub](https://github.com/numpy/numpy) repository as well as a few functions relating to downloading files copied from the [Keras GitHub](https://github.com/keras-team/keras) repository. The copyrights for these parts of the code are attributed to their respective owners in the [LICENSE](https://github.com/thaler-lab/EnergyFlow/blob/master/LICENSE) file.


### PR DESCRIPTION
* Replace 'pkomiske/EnergyFlow' with 'thaler-lab/EnergyFlow'.
* Replace 'pkomiske/Wasserstein' with 'thaler-lab/Wasserstein'.
* Replace 'pkomiske.github.io' with 'thaler-lab.github.io'.
* Update CI status badge to point to GitHub Actions. [![Build Status](https://github.com/thaler-lab/EnergyFlow/actions/workflows/test-energyflow.yml/badge.svg)](https://github.com/thaler-lab/EnergyFlow/actions/workflows/test-energyflow.yml?query=branch%3Amaster)

This was all done using patterns like

```
git grep --name-only "pkomiske/EnergyFlow" | xargs sed -i 's|pkomiske/EnergyFlow|thaler-lab/EnergyFlow|g'
```

so after having manually inspected the remaining output from

```
git grep "pkomiske"
```

this PR should get everything needed for updating the docs.