### PR TITLE
fix: Use numpy.random.generator with seed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ classifiers = [
 dependencies = [
     "h5py >= 2.9.0",
     "importlib-metadata>=1.4.0; python_version<\"3.8\"",
-    "numpy >= 1.12.0",
+    "numpy >= 1.17.0",
     "six",
     "wasserstein >= 1.0.1",
 ]

--- a/tests/test_efm.py
+++ b/tests/test_efm.py
@@ -29,7 +29,8 @@ def slow_efm(zs, nhats, v):
 @pytest.mark.parametrize('v', list(range(0,2)))
 def test_efms(v, measure, normed, M):
 
-    events = ef.gen_random_events(2, M)
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events(2, M, rng=rng)
     e = ef.EFM(v, measure=measure, normed=normed, coords='epxpypz')
 
     for event in events:
@@ -55,7 +56,8 @@ def test_efms(v, measure, normed, M):
 @pytest.mark.parametrize('M', [1, 10, 50, 100, 500])
 @pytest.mark.parametrize('v', list(range(0,2)))
 def test_efm_batch_compute(v, M, measure, normed):
-    events = ef.gen_random_events(2, M)
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events(2, M, rng=rng)
     e = ef.EFM(v, measure=measure, normed=normed, coords='epxpypz')
 
     r1 = [e.compute(event) for event in events]
@@ -74,7 +76,8 @@ def test_efm_vs_efmset_compute(sigs, M, measure, normed):
     efmset = ef.EFMSet(sigs, measure=measure, normed=normed, coords='epxpypz')
     efms = [ef.EFM(*sig, measure=measure, normed=normed, coords='epxpypz') for sig in sigs]
 
-    for event in ef.gen_random_events(2, M):
+    rng = np.random.default_rng(seed=1234567890)
+    for event in ef.gen_random_events(2, M, rng=rng):
         efm_dict = efmset.compute(event)
         for sig,efm in zip(sigs,efms):
             print(sig, np.max(np.abs(efm_dict[sig] - efm.compute(event))))
@@ -91,7 +94,8 @@ def test_efm_vs_efmset_batch_compute(sigs, M, measure, normed):
     efmset = ef.EFMSet(sigs, measure=measure, normed=normed, coords='epxpypz')
     efms = [ef.EFM(*sig, measure=measure, normed=normed, coords='epxpypz') for sig in sigs]
 
-    events = ef.gen_random_events(2, M)
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events(2, M, rng=rng)
     efm_dict = efmset.batch_compute(events)
 
     for sig,efm in zip(sigs,efms):

--- a/tests/test_efp.py
+++ b/tests/test_efp.py
@@ -84,7 +84,9 @@ def test_batch_compute_vs_compute(measure, beta, kappa, normed):
         pytest.skip('normed not supported with kappa=pf')
     if ('efm' in measure) and (beta != 2):
         pytest.skip('only beta=2 can use efm measure')
-    events = ef.gen_random_events(10, 15)
+
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events(10, 15, rng=rng)
     s = ef.EFPSet('d<=6', measure=measure, beta=beta, kappa=kappa, normed=normed)
     r_batch = s.batch_compute(events, n_jobs=1)
     r = np.asarray([s.compute(event) for event in events])
@@ -94,7 +96,7 @@ def test_batch_compute_vs_compute(measure, beta, kappa, normed):
 @pytest.mark.slow
 @pytest.mark.efp
 @pytest.mark.efm
-@pytest.mark.parametrize('event', ef.gen_random_events(3, 15))
+@pytest.mark.parametrize('event', ef.gen_random_events(3, 15, rng=np.random.default_rng(seed=1234567890)))
 @pytest.mark.parametrize('normed', [True, False])
 @pytest.mark.parametrize('kappa', [0, 0.5, 1, 'pf'])
 @pytest.mark.parametrize('beta', [.5, 1, 2])
@@ -119,7 +121,7 @@ def test_efpset_vs_efps(measure, beta, kappa, normed, event):
 @pytest.mark.parametrize('normed', [True, False])
 @pytest.mark.parametrize('kappa', [0, 0.5, 1])
 @pytest.mark.parametrize('beta', [.5, 1, 2])
-@pytest.mark.parametrize('event', ef.gen_random_events(3, 15))
+@pytest.mark.parametrize('event', ef.gen_random_events(3, 15, rng=np.random.default_rng(seed=1234567890)))
 def test_efp_kappa_hadr(event, beta, kappa, normed, kappa_normed_behavior):
 
     asymbox_graph = [(0,1),(0,1),(1,2),(1,2),(1,2),(2,3),(2,3),(2,3),(2,3),(3,0),(0,3),(3,0)]
@@ -150,7 +152,7 @@ def test_efp_kappa_hadr(event, beta, kappa, normed, kappa_normed_behavior):
 # test that efps, efms, and naive all agree
 @pytest.mark.efp
 @pytest.mark.efm
-@pytest.mark.parametrize('event', ef.gen_random_events(4, 15))
+@pytest.mark.parametrize('event', ef.gen_random_events(4, 15, rng=np.random.default_rng(seed=1234567890)))
 @pytest.mark.parametrize('normed', [True, False])
 @pytest.mark.parametrize('measure', ['hadrefm', 'eeefm'])
 def test_efp_efm_naive_compute(measure, normed, event):
@@ -237,8 +239,9 @@ def test_linear_relations(measure):
         'triangledumbbell': [(0,1),(0,1),(2,3),(3,4),(4,2)]
         }
 
+    rng = np.random.default_rng(seed=1234567890)
     # pick a random event with 2 particles
-    event = ef.gen_random_events(1, 2, dim=4)
+    event = ef.gen_random_events(1, 2, dim=4, rng=rng)
 
     # compute the value of all of the EFPs on this event
     d = {name: ef.EFP(graph, measure=measure, coords='epxpypz')(event) for name,graph in graphs.items()}
@@ -254,7 +257,7 @@ def test_linear_relations(measure):
 
     # Four Dimensions
     # pick a random event in 4 dimensions
-    event = ef.gen_random_events(1, 25, dim=4)
+    event = ef.gen_random_events(1, 25, dim=4, rng=rng)
 
     # compute the value of all of the EFPs on this event
     d = {name: ef.EFP(graph, measure=measure, coords='epxpypz')(event) for name,graph in graphs.items()}

--- a/tests/test_emd.py
+++ b/tests/test_emd.py
@@ -222,8 +222,9 @@ def emde(ev0, ev1, R=1.0, beta=1.0, return_flow=False):
 @pytest.mark.parametrize('backend', ['wasserstein', 'pot'])
 def test_emde(backend, M, R, beta):
     emd = ef.emd.emd if backend == 'wasserstein' else ef.emd.emd_pot
-    events1 = np.random.rand(nev, M, 3)
-    events2 = np.random.rand(nev, M, 3)
+    rng = np.random.default_rng(seed=1234567890)
+    events1 = rng.random((nev, M, 3))
+    events2 = rng.random((nev, M, 3))
 
     for ev1 in events1:
         for ev2 in events2:

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -40,7 +40,7 @@ def test_measure_hadr_ptyphi(pts, ys, phis, beta, kappa, normed, kappa_normed_be
 @pytest.mark.parametrize('normed', [True, False])
 @pytest.mark.parametrize('kappa', [0, .5, 1])
 @pytest.mark.parametrize('beta', [.2, 1, 2])
-@pytest.mark.parametrize('event', ef.gen_random_events(3, 15))
+@pytest.mark.parametrize('event', ef.gen_random_events(3, 15, rng=np.random.default_rng(seed=1234567890)))
 def test_measure_hadr_p4s(event, beta, kappa, normed, kappa_normed_behavior):
     M = len(event)
     pTs = np.sqrt(event[:,1]**2 + event[:,2]**2)
@@ -138,7 +138,7 @@ def test_measure_ee(event, beta, theta_eps, kappa, normed, kappa_normed_behavior
 
 @pytest.mark.measure
 @pytest.mark.parametrize('check_input', [True, False])
-@pytest.mark.parametrize('event', ef.gen_random_events(2,15))
+@pytest.mark.parametrize('event', ef.gen_random_events(2, 15, rng=np.random.default_rng(seed=1234567890)))
 @pytest.mark.parametrize('measure', ['hadr', 'hadrdot', 'hadrefm', 'ee', 'eeefm'])
 def test_measure_list_input(measure, event, check_input):
     meas = ef.Measure(measure, check_input=check_input)

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -24,7 +24,8 @@ def test_C2D2C3(measure, beta, normed):
         pytest.skip('only beta=2 can use efm measure')
 
     # generate a random event with 10 particles
-    event = ef.gen_random_events(1, 10, dim=4)
+    rng = np.random.default_rng(seed=1234567890)
+    event = ef.gen_random_events(1, 10, dim=4, rng=rng)
 
     # specify the relevant graphs and EFPs to compute C1, D2, C3
     line = ef.EFP([(0,1)], measure=measure, coords='epxpypz', beta=beta, normed=True)(event)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -33,10 +33,11 @@ def test_gen_massless_phase_space(nevents, nparticles):
 @pytest.mark.parametrize('dim', [3, 4, 8])
 @pytest.mark.parametrize('mass', [0, 1.5, 'random', 'array'])
 def test_gen_random_events(nevents, nparticles, dim, mass):
+    rng = np.random.default_rng(seed=1234567890)
     if mass == 'array':
-        mass = np.random.rand(nevents, nparticles)
+        mass = rng.random((nevents, nparticles))
 
-    events = ef.gen_random_events(nevents, nparticles, dim=dim, mass=mass)
+    events = ef.gen_random_events(nevents, nparticles, dim=dim, mass=mass, rng=rng)
 
     assert events.shape == (nevents, nparticles, dim)
 
@@ -49,7 +50,8 @@ def test_gen_random_events(nevents, nparticles, dim, mass):
 @pytest.mark.parametrize('nevents', [20, 200])
 @pytest.mark.parametrize('dim', [3, 4, 8])
 def test_gen_random_events_mcom(nevents, nparticles, dim):
-    events = ef.gen_random_events_mcom(nevents, nparticles, dim=dim)
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events_mcom(nevents, nparticles, dim=dim, rng=rng)
 
     assert events.shape == (nevents, nparticles, dim)
     assert epsilon_diff(ef.ms_from_ps(events)**2/dim, 0, 10**-12)
@@ -64,14 +66,15 @@ def test_gen_random_events_mcom(nevents, nparticles, dim):
 					                'pt2s_from_p4s', 'ys_from_p4s', 'etas_from_p4s',
 					                'phis_from_p4s', 'm2s_from_p4s', 'ms_from_p4s'])
 def test_shapes_from_p4s(method, nevents, nparticles):
-	events = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
-	event, particle = events[0], events[0,0]
+    rng = np.random.default_rng(seed=1234567890)
+    events = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
+    event, particle = events[0], events[0,0]
 
-	func = getattr(ef, method)
-	results = func(events)
+    func = getattr(ef, method)
+    results = func(events)
 
-	assert epsilon_diff(results[0],  func(event))
-	assert epsilon_diff(results[0,0], func(particle))
+    assert epsilon_diff(results[0], func(event))
+    assert epsilon_diff(results[0,0], func(particle))
 
 @pytest.mark.utils
 @pytest.mark.parametrize('nparticles', [1, 20])
@@ -79,7 +82,8 @@ def test_shapes_from_p4s(method, nevents, nparticles):
 @pytest.mark.parametrize('method', ['p4s_from_ptyphims', 'p4s_from_ptyphipids',])
                                     #'sum_ptyphims', 'sum_ptyphipids'])
 def test_shapes_from_ptyphis(method, nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
     ptyphims = ef.ptyphims_from_p4s(p4s)
 
     func = getattr(ef, method)
@@ -102,7 +106,8 @@ def test_shapes_from_ptyphis(method, nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_pts_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     pts = ef.pts_from_p4s(p4s)
     slow_pts = []
@@ -119,7 +124,8 @@ def test_pts_from_p4s(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_pt2s_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     pt2s = ef.pt2s_from_p4s(p4s)
     slow_pt2s = []
@@ -136,7 +142,8 @@ def test_pt2s_from_p4s(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_ys_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
     ys = 0.5*np.log((p4s[...,0] + p4s[...,3])/(p4s[...,0] - p4s[...,3]))
 
     assert epsilon_diff(ys, ef.ys_from_p4s(p4s))
@@ -145,7 +152,8 @@ def test_ys_from_p4s(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_etas_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     p3tots = np.linalg.norm(p4s[...,1:], axis=-1)
     etas = 0.5*np.log((p3tots + p4s[...,3])/(p3tots - p4s[...,3]))
@@ -182,7 +190,8 @@ def test_phis_from_p4s(nevents, nparticles, phi_ref):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_ms_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     ms = ef.ms_from_p4s(p4s)
     slow_ms = []
@@ -199,7 +208,8 @@ def test_ms_from_p4s(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_m2s_from_p4s(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     m2s = ef.m2s_from_p4s(p4s)
     slow_m2s = []
@@ -217,7 +227,8 @@ def test_m2s_from_p4s(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_etas_from_pts_ys_ms(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
     ptyphims = ef.ptyphims_from_p4s(p4s)
 
     etas = ef.etas_from_p4s(p4s)
@@ -240,7 +251,8 @@ def test_etas_from_pts_ys_ms(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 20])
 @pytest.mark.parametrize('nevents', [1, 10])
 def test_ys_from_pts_etas_ms(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
 
     ys = ef.ys_from_p4s(p4s)
     y_primes = ef.ys_from_pts_etas_ms(ef.pts_from_p4s(p4s), ef.etas_from_p4s(p4s), ef.ms_from_p4s(p4s))
@@ -261,7 +273,8 @@ def test_ys_from_pts_etas_ms(nevents, nparticles):
 @pytest.mark.parametrize('nparticles', [1, 500])
 @pytest.mark.parametrize('nevents', [1, 100])
 def test_coordinate_transforms(nevents, nparticles):
-    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random').reshape(nevents, nparticles, 4)
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(nevents, nparticles, dim=4, mass='random', rng=rng).reshape(nevents, nparticles, 4)
     ptyphims = ef.ptyphims_from_p4s(p4s)
     new_p4s = ef.p4s_from_ptyphims(ptyphims)
 
@@ -297,8 +310,9 @@ def test_phifix(phi_ref, nevents, nparticles):
 @pytest.mark.parametrize('nevents', [1, 10])
 @pytest.mark.parametrize('dim', [2, 4, 8])
 def test_ms_from_ps(dim, nevents, nparticles):
-    masses = np.random.rand(nevents, nparticles)
-    events = ef.gen_random_events(nevents, nparticles, mass=masses, dim=dim)
+    rng = np.random.default_rng(seed=1234567890)
+    masses = rng.random((nevents, nparticles))
+    events = ef.gen_random_events(nevents, nparticles, mass=masses, dim=dim, rng=rng)
     masses = masses.reshape(events.shape[:-1])
 
     results = ef.ms_from_ps(events)
@@ -311,7 +325,8 @@ def test_ms_from_ps(dim, nevents, nparticles):
 @pytest.mark.parametrize('scheme', ['escheme', 'ptscheme'])
 @pytest.mark.parametrize('nparticles', [1, 20])
 def test_sum_ptyphims(nparticles, scheme):
-    p4s = ef.gen_random_events(10, nparticles, dim=4, mass='random')
+    rng = np.random.default_rng(seed=1234567890)
+    p4s = ef.gen_random_events(10, nparticles, dim=4, mass='random', rng=rng)
     ptyphims = ef.ptyphims_from_p4s(p4s)
 
     if scheme == 'escheme':


### PR DESCRIPTION
Requires PR #54 to go in first and then should be rebased.

## Description

* Require numpy lower bound of `v1.17.0` as this is the oldest NumPy with a Python 3.7+ wheel that supports `numpy.random.default_rng`.
* NumPy now recommends avoiding use of `numpy.random.random` and only using the generators. Add arguments for passing an optional `numpy.random.generator` and `seed`. Use a `rng` in the tests as test numbers should be random but reproducible so that tests don't pass or fail due to machine entropy.
   - c.f. https://numpy.org/doc/2.0/reference/random/generator.html
* This change should be applied across the entire test suite, but hasn't there might be cases of numpy.random that were missed.

This is related to [NEP 19](https://numpy.org/neps/nep-0019-rng-policy.html). (Taken from https://github.com/scikit-hep/pyhf/issues/1795)