### PR TITLE
ci: Add x86_64 macOS and Python 3.11 and Python 3.12 to testing

### DIFF
--- a/.github/workflows/test-energyflow.yml
+++ b/.github/workflows/test-energyflow.yml
@@ -23,7 +23,7 @@ jobs:
       # TODO Remove when Windows builds stop failing (see #47)
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.8', '3.9', '3.10']
 
     steps:

--- a/.github/workflows/test-energyflow.yml
+++ b/.github/workflows/test-energyflow.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout repository and submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",


### PR DESCRIPTION
Requires PR #54 and PR #55 to go in first and then should be rebased.

## Description

* Add x86_64 macOS via macos-13 'runs-on'.
* Add Python 3.11 and 3.12 to testing.
* Add Python 3.11 and Python 3.12 PyPI trove classifiers.