### PR TITLE
build: Use hatch-vcs to version from vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ fastjet-3.3.4
 *.so
 *.a
 **/.svn
+
+# dynamic versioning
+energyflow/_version.py

--- a/energyflow/__init__.py
+++ b/energyflow/__init__.py
@@ -28,6 +28,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+
 from __future__ import absolute_import
 
 # import top-level submodules
@@ -41,6 +42,7 @@ from . import gen
 from . import measure
 from . import obs
 from . import utils
+from energyflow._version import version as __version__
 
 # import top-level attributes
 from .datasets import *
@@ -51,12 +53,16 @@ from .measure import *
 from .obs import *
 from .utils import *
 
-__all__ = (datasets.__all__ +
-           efm.__all__ +
-           efp.__all__ +
-           gen.__all__ +
-           measure.__all__ +
-           obs.__all__ +
-           utils.__all__)
+__all__ = (
+    datasets.__all__
+    + efm.__all__
+    + efp.__all__
+    + gen.__all__
+    + measure.__all__
+    + obs.__all__
+    + utils.__all__
+) + ["__version__"]
 
-__version__ = '1.3.3a0'
+
+def __dir__():
+    return __all__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling"]
+requires = [
+    "hatchling>=1.13.0",
+    "hatch-vcs>=0.3.0",
+]
 build-backend = "hatchling.build"
 
 [project]
@@ -111,7 +114,13 @@ Issues = "https://github.com/thaler-lab/EnergyFlow/issues"
 "Source Code" = "https://github.com/thaler-lab/EnergyFlow"
 
 [tool.hatch.version]
-path = "energyflow/__init__.py"
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "energyflow/_version.py"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
* Use hatch-vcs to generate a dynamic version `_version.py` file with information from the version control system.
* Ignore the dynamic version file.