### PR TITLE
build: Disallow h5py v3.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "h5py >= 2.9.0",
+    "h5py >= 2.9.0,!=3.11.0",
     "importlib-metadata>=1.4.0; python_version<\"3.8\"",
     "numpy >= 1.17.0",
     "wasserstein >= 1.0.1",


### PR DESCRIPTION
* h5py v3.11.0 is missing wheels for aarch64 Linux which causes issues when h5py is a dependency in other package testing workflows.