### PR TITLE
ci: Correct environment names for trusted publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
 
   publish-testpypi:
     needs: [dist]
+    # Restrict to the environment set for the trusted publisher
     environment:
       name: testpypi
     permissions:
@@ -59,8 +60,9 @@ jobs:
 
   publish:
     needs: [dist]
+    # Restrict to the environment set for the trusted publisher
     environment:
-      name: pypi
+      name: publish-package
     permissions:
       id-token: write
       attestations: write


### PR DESCRIPTION
* The environment name in the publishing workflow needs to be the same as an existing GitHub environment for deployment of the project. Rename 'pypi' to 'publish-package'.

```
* The environment name in the publishing workflow needs to be the same as
  an existing GitHub environment for deployment of the project. Rename
  'pypi' to 'publish-package'.
```