### PR TITLE
build: Require Python 3.9+

### DIFF
--- a/.github/workflows/test-energyflow.yml
+++ b/.github/workflows/test-energyflow.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout repository and submodules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "EnergyFlow"
 dynamic = ["version"]
 description = "Python package for the Energy Flow suite of particle physics tools"
 readme = "README.md"
-requires-python = ">= 3.7"
+requires-python = ">= 3.9"
 authors = [
     { name = "Patrick T. Komiske III", email = "pkomiske@mit.edu" },
 ]
@@ -62,8 +62,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This is in support of a minor release [`v1.4.0`](https://github.com/thaler-lab/EnergyFlow/releases/tag/v1.4.0) which will be the same as [`v1.3.4`](https://github.com/thaler-lab/EnergyFlow/releases/tag/v1.3.4) except it drops support for EOL Pythons.

* Drop support for Python 3.7 and Python 3.8 which are EOL and require Python 3.9+ for install.

```
┌───────┬────────────┬─────────┬────────────────┬────────────┬────────────┐
│ cycle │  release   │ latest  │ latest release │  support   │    eol     │
├───────┼────────────┼─────────┼────────────────┼────────────┼────────────┤
│ 3.13  │ 2024-10-07 │ 3.13.0  │   2024-10-07   │ 2026-10-01 │ 2029-10-31 │
│ 3.12  │ 2023-10-02 │ 3.12.7  │   2024-10-01   │ 2025-04-02 │ 2028-10-31 │
│ 3.11  │ 2022-10-24 │ 3.11.10 │   2024-09-07   │ 2024-04-01 │ 2027-10-31 │
│ 3.10  │ 2021-10-04 │ 3.10.15 │   2024-09-07   │ 2023-04-05 │ 2026-10-31 │
│ 3.9   │ 2020-10-05 │ 3.9.20  │   2024-09-06   │ 2022-05-17 │ 2025-10-31 │
│ 3.8   │ 2019-10-14 │ 3.8.20  │   2024-09-06   │ 2021-05-03 │ 2024-10-07 │
│ 3.7   │ 2018-06-27 │ 3.7.17  │   2023-06-05   │ 2020-06-27 │ 2023-06-27 │
```

* Remove Python 3.8 from use in CI.