### PR TITLE
docs: Add release notes for v1.4.0

### DIFF
--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -78,6 +78,8 @@
                     </li>
                     <li class="toctree-l1 current"><a class="reference internal current" href="./">Release Notes</a>
     <ul class="current">
+    <li class="toctree-l2"><a class="reference internal" href="#14x">1.4.x</a>
+    </li>
     <li class="toctree-l2"><a class="reference internal" href="#13x">1.3.x</a>
     </li>
     <li class="toctree-l2"><a class="reference internal" href="#12x">1.2.x</a>
@@ -159,6 +161,13 @@
             <div class="section">
 
                 <h1 id="release-notes">Release Notes</h1>
+<h2 id="14x">1.4.x</h2>
+<a href="https://github.com/thaler-lab/EnergyFlow/compare/v1.3.4...v1.4.0">
+  <p><strong>1.4.0</strong></p>
+</a>
+<ul>
+  <li>Require Python <code>3.9+</code>, dropping support for Python <code>3.7</code> and Python <code>3.8</code> which are <a href="https://devguide.python.org/versions/">end of life</a>.</li>
+</ul>
 <h2 id="13x">1.3.x</h2>
 <a href="https://github.com/thaler-lab/EnergyFlow/compare/v1.3.3...v1.3.4">
   <p><strong>1.3.4</strong></p>


### PR DESCRIPTION
* v1.4.0 is unchanged from v1.3.4 except for the requirement of Python 3.9+.